### PR TITLE
Listener injection

### DIFF
--- a/node.go
+++ b/node.go
@@ -1,7 +1,6 @@
 package swarm
 
 import (
-	"fmt"
 	"log"
 	"net"
 	"time"
@@ -42,14 +41,10 @@ func NewNode(delegate Delegate, options Options) *Node {
 }
 
 // Serve starts the gRPC server.
-func (node *Node) Serve() error {
+func (node *Node) Serve(listener net.Listener) error {
 	rpc.RegisterSwarmNodeServer(node.Server, node)
-	listener, err := net.Listen("tcp", fmt.Sprintf("%s:%s", node.Options.Host, node.Options.Port))
-	if err != nil {
-		return err
-	}
 	if node.Options.Debug >= DebugLow {
-		log.Printf("Listening at %s:%s\n", node.Options.Host, node.Options.Port)
+		log.Printf("Listening on %v\n", listener.Addr())
 	}
 	return node.Server.Serve(listener)
 }

--- a/node_test.go
+++ b/node_test.go
@@ -3,6 +3,7 @@ package swarm_test
 import (
 	"fmt"
 	"log"
+	"net"
 	"sync"
 	"time"
 
@@ -51,13 +52,12 @@ var _ = Describe("Bootstrapping", func() {
 		bootstrapNodes, bootstrapRoutingTable, err = GenerateBootstrapTopology(topology, numberOfNodes, newMockDelegate())
 		Ω(err).ShouldNot(HaveOccurred())
 		for i, node := range bootstrapNodes {
-			By(fmt.Sprintf("%dth bootstrap node is %s", i, node.MultiAddress()))
-		}
-		for _, node := range bootstrapNodes {
-			go func(node *swarm.Node) {
+			go func(i int, node *swarm.Node) {
 				defer GinkgoRecover()
-				Ω(node.Serve()).ShouldNot(HaveOccurred())
-			}(node)
+				listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", 3000+i))
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(node.Serve(listener)).ShouldNot(HaveOccurred())
+			}(i, node)
 		}
 		time.Sleep(time.Second)
 		err = ping(bootstrapNodes, bootstrapRoutingTable)
@@ -71,11 +71,13 @@ var _ = Describe("Bootstrapping", func() {
 				swarmNode.Options.BootstrapMultiAddresses = append(swarmNode.Options.BootstrapMultiAddresses, bootstrapNode.MultiAddress())
 			}
 		}
-		for _, node := range swarmNodes {
-			go func(node *swarm.Node) {
+		for i, node := range swarmNodes {
+			go func(i int, node *swarm.Node) {
 				defer GinkgoRecover()
-				Ω(node.Serve()).ShouldNot(HaveOccurred())
-			}(node)
+				listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", 4000+i))
+				Ω(err).ShouldNot(HaveOccurred())
+				Ω(node.Serve(listener)).ShouldNot(HaveOccurred())
+			}(i, node)
 		}
 		time.Sleep(time.Second)
 	}

--- a/node_test.go
+++ b/node_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Bootstrapping", func() {
 		for i, node := range bootstrapNodes {
 			go func(i int, node *swarm.Node) {
 				defer GinkgoRecover()
-				listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", 3000+i))
+				listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", NodePortBootstrap+i))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(node.Serve(listener)).ShouldNot(HaveOccurred())
 			}(i, node)
@@ -74,7 +74,7 @@ var _ = Describe("Bootstrapping", func() {
 		for i, node := range swarmNodes {
 			go func(i int, node *swarm.Node) {
 				defer GinkgoRecover()
-				listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", 4000+i))
+				listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", NodePortSwarm+i))
 				Ω(err).ShouldNot(HaveOccurred())
 				Ω(node.Serve(listener)).ShouldNot(HaveOccurred())
 			}(i, node)

--- a/options.go
+++ b/options.go
@@ -16,8 +16,6 @@ const (
 
 // Options that parameterize the behavior of Nodes.
 type Options struct {
-	Host                    string
-	Port                    string
 	MultiAddress            identity.MultiAddress
 	BootstrapMultiAddresses identity.MultiAddresses
 

--- a/swarm_test.go
+++ b/swarm_test.go
@@ -57,8 +57,6 @@ func GenerateNodes(port, numberOfNodes int, delegate swarm.Delegate) ([]*swarm.N
 		node := swarm.NewNode(
 			delegate,
 			swarm.Options{
-				Host:            "127.0.0.1",
-				Port:            fmt.Sprintf("%d", port+i),
 				MultiAddress:    multiAddress,
 				Debug:           DefaultOptionsDebug,
 				Alpha:           DefaultOptionsAlpha,


### PR DESCRIPTION
The `Serve` method now takes in a `net.Listener` so that nodes using a mixture of the swarm, xing, and atom networks can re-use the same port.